### PR TITLE
Export the actual position in the stream outside of library

### DIFF
--- a/PcapngFile/Reader.cs
+++ b/PcapngFile/Reader.cs
@@ -346,5 +346,7 @@ namespace PcapngFile
 		{
 			this.reader.BaseStream.Seek(0, SeekOrigin.Begin);
 		}
+
+        public float CurrentPos => reader.BaseStream.Position * 1.0f / reader.BaseStream.Length;
 	}
 }


### PR DESCRIPTION
The position is very usable for reporting to UI where in the stream the current worker (thread) is.

There are two possible variants, export Length + Position and let the upper layer to compute percent position inside, or let the lib to compute actual position in percent (this commit)

This API should be in master in one or both ways.